### PR TITLE
allow update backupmariadbs finalizers

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -198,6 +198,12 @@ rules:
 - apiGroups:
   - database.mmontes.io
   resources:
+  - backupmariadbs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - database.mmontes.io
+  resources:
   - usermariadbs/status
   verbs:
   - get


### PR DESCRIPTION
Creating backup CrinJob failed because the operator did not have the permission to update backupmariadbs finalizers  

```
$ kubectl get backupmariadbs
NAME               COMPLETE   STATUS                   MARIADB   AGE
backup-scheduled   False      Error creating CronJob   mariadb   3s
```

Error logs in operator:
```
creating CronJob: cronjobs.batch is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on
```
The problem occurred on OpenShift 4.11 

Added permission to update backupmariadbs/finalizers
