### PR TITLE
Fixed default prometheus scrape internal and timeout

### DIFF
--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -32,10 +32,8 @@ type Exporter struct {
 type ServiceMonitor struct {
 	// +kubebuilder:validation:Required
 	PrometheusRelease string `json:"prometheusRelease"`
-	// +kubebuilder:default='10s'
-	Interval string `json:"interval,omitempty"`
-	// +kubebuilder:default='10s'
-	ScrapeTimeout string `json:"scrapeTimeout,omitempty"`
+	Interval          string `json:"interval,omitempty"`
+	ScrapeTimeout     string `json:"scrapeTimeout,omitempty"`
 }
 
 type Metrics struct {

--- a/config/crd/bases/mariadb.mmontes.io_mariadbs.yaml
+++ b/config/crd/bases/mariadb.mmontes.io_mariadbs.yaml
@@ -1822,12 +1822,10 @@ spec:
                   serviceMonitor:
                     properties:
                       interval:
-                        default: '''10s'''
                         type: string
                       prometheusRelease:
                         type: string
                       scrapeTimeout:
-                        default: '''10s'''
                         type: string
                     required:
                     - prometheusRelease

--- a/deploy/charts/mariadb-operator/crds/crds.yaml
+++ b/deploy/charts/mariadb-operator/crds/crds.yaml
@@ -4047,12 +4047,10 @@ spec:
                   serviceMonitor:
                     properties:
                       interval:
-                        default: '''10s'''
                         type: string
                       prometheusRelease:
                         type: string
                       scrapeTimeout:
-                        default: '''10s'''
                         type: string
                     required:
                     - prometheusRelease

--- a/deploy/crds/crds.yaml
+++ b/deploy/crds/crds.yaml
@@ -4047,12 +4047,10 @@ spec:
                   serviceMonitor:
                     properties:
                       interval:
-                        default: '''10s'''
                         type: string
                       prometheusRelease:
                         type: string
                       scrapeTimeout:
-                        default: '''10s'''
                         type: string
                     required:
                     - prometheusRelease

--- a/hack/add_host.sh
+++ b/hack/add_host.sh
@@ -9,5 +9,5 @@ if [ -n "$(grep $HOSTNAME /etc/hosts)" ]; then
   echo "\"$HOSTNAME\" host already exists in /etc/hosts"
 else
   echo "Adding \"$HOSTNAME\" to /etc/hosts";
-  sudo -- sh -c -e "echo '$IP\t$HOSTNAME' >> /etc/hosts";
+  sudo -- sh -c -e "echo '\n# mariadb-operator\n$IP\t$HOSTNAME' >> /etc/hosts";
 fi


### PR DESCRIPTION
Default kubebuilder values for prometheus scrape monitor and interval include quotes that cause problems when creating the `ServiceMonitor` resources. They have been removed and the prometheus operator will use its default values instead.

Related to:
- https://github.com/mmontes11/mariadb-operator/issues/38